### PR TITLE
Update NSUrlSessionHandler to cancel request if provided cancellationToken is already canceled

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -253,21 +253,24 @@ namespace Foundation {
 
 			cancellationToken.Register (() => {
 				RemoveInflightData (dataTask);
+				dataTask?.Cancel();
 				tcs.TrySetCanceled ();
 			});
 
-			lock (inflightRequestsLock)
-				inflightRequests.Add (dataTask, new InflightData {
-					RequestUrl = request.RequestUri.AbsoluteUri,
-					CompletionSource = tcs,
-					CancellationToken = cancellationToken,
-					Stream = new NSUrlSessionDataTaskStream (),
-					Request = request
-				});
+			if (!cancellationToken.IsCancellationRequested) {
+				lock (inflightRequestsLock)
+					inflightRequests.Add (dataTask, new InflightData {
+						RequestUrl = request.RequestUri.AbsoluteUri,
+						CompletionSource = tcs,
+						CancellationToken = cancellationToken,
+						Stream = new NSUrlSessionDataTaskStream (),
+						Request = request
+					});
 
-			if (dataTask.State == NSUrlSessionTaskState.Suspended)
-				dataTask.Resume ();
-
+				if (dataTask.State == NSUrlSessionTaskState.Suspended)
+					dataTask.Resume ();
+			}
+			
 			return await tcs.Task.ConfigureAwait (false);
 		}
 


### PR DESCRIPTION
An already cancelled request is no more sent and the task nicely canceled.

It fix this issue https://github.com/xamarin/xamarin-macios/issues/5333 on my tests.